### PR TITLE
modify bash-commands to support other OS dylibs

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -4,29 +4,31 @@ on:
   push:
     paths-ignore:
       - "**.md"
-      - ".all-contributorsrc"
+      - .all-contributorsrc
   pull_request:
     paths-ignore:
       - "**.md"
-      - ".all-contributorsrc"
+      - .all-contributorsrc
   schedule:
-    - cron: "0 0 * * 5"
+    - cron: 0 0 * * 5
 
 jobs:
   plugin_test:
     strategy:
       matrix:
-        os: [macos-latest, ubuntu-latest]
+        os:
+          - macos-latest
+          - ubuntu-latest
 
     runs-on: ${{ matrix.os }}
 
     steps:
       - name: asdf_plugin_test
-        env:
-          GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        uses: asdf-vm/actions/plugin-test@v1.0.0
+        uses: asdf-vm/actions/plugin-test@v1
         with:
           command: haxe --version
+        env:
+          GITHUB_API_TOKEN: ${{ github.token }}
 
   test:
     runs-on: macos-latest
@@ -35,28 +37,42 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v2
 
-      - name: Install asdf
-        run: git clone https://github.com/asdf-vm/asdf.git $HOME/asdf
+      - name: asdf_setup
+        uses: asdf-vm/actions/setup@v1
+
+      - name: Add plugin
+        run: asdf plugin add haxe $GITHUB_WORKSPACE
 
       - name: Test plugin
-        run: |
-          . $HOME/asdf/asdf.sh
-          asdf plugin-add haxe $GITHUB_WORKSPACE
-          bats test
+        run: bats test
         env:
-          GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_API_TOKEN: ${{ github.token }}
 
   link-test:
-    runs-on: macos-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - macos-latest
+          - ubuntu-latest
+
+    runs-on: ${{ matrix.os }}
 
     steps:
-      - name: Create .tool-versions file
-        run: |
-          echo "haxe 4.0.5" >> .tool-versions
-          echo "neko 2.3.0" >> .tool-versions
+      - name: Checkout code
+        uses: actions/checkout@v2
 
-      - name: asdf_install
-        uses: asdf-vm/actions/install@v1.0.0
+      - name: asdf_setup
+        uses: asdf-vm/actions/setup@v1
+
+      - name: Install plugins and tools
+        run: |
+          asdf plugin add haxe $GITHUB_WORKSPACE
+          asdf plugin add neko
+          asdf install haxe 4.1.3
+          asdf install neko 2.3.0
+          asdf global haxe 4.1.3
+          asdf global neko 2.3.0
 
       - name: Run link command
         run: asdf haxe neko dylibs link

--- a/lib/commands/command-neko.bash
+++ b/lib/commands/command-neko.bash
@@ -53,12 +53,11 @@ dylibs_link() {
   neko_path=$(asdf where neko)
   dylib_ext="dylib"
   case "$OSTYPE" in
-    solaris*) dylib_ext="so"    ;;
-    darwin*)  dylib_ext="dylib" ;;
-    linux*)   dylib_ext="so"    ;;
-    bsd*)     dylib_ext="so"    ;;
-    msys*)    dylib_ext="dll"   ;;
-    *)        dylib_ext="dylib" ;;
+    darwin*) dylib_ext="dylib" ;;
+    linux*) dylib_ext="so" ;;
+    bsd*) dylib_ext="so" ;;
+    msys*) dylib_ext="dll" ;;
+    *) dylib_ext="dylib" ;;
   esac
   find "$neko_path/bin" -mindepth 1 -maxdepth 1 \
     -name "*.$dylib_ext" \
@@ -70,12 +69,11 @@ dylibs_unlink() {
   haxe_path=$(asdf where haxe)
   dylib_ext="dylib"
   case "$OSTYPE" in
-    solaris*) dylib_ext="so"    ;;
-    darwin*)  dylib_ext="dylib" ;;
-    linux*)   dylib_ext="so"    ;;
-    bsd*)     dylib_ext="so"    ;;
-    msys*)    dylib_ext="dll"   ;;
-    *)        dylib_ext="dylib" ;;
+    darwin*) dylib_ext="dylib" ;;
+    linux*) dylib_ext="so" ;;
+    bsd*) dylib_ext="so" ;;
+    msys*) dylib_ext="dll" ;;
+    *) dylib_ext="dylib" ;;
   esac
   find "$haxe_path/bin" -mindepth 1 -maxdepth 1 \
     -type l -path "*neko*.$dylib_ext" \
@@ -83,21 +81,19 @@ dylibs_unlink() {
 }
 
 dylibs_which() {
-  set -x
   local haxe_path
   haxe_path=$(asdf where haxe)
   dylib_ext="dylib"
   case "$OSTYPE" in
-    solaris*) dylib_ext="so"    ;;
-    darwin*)  dylib_ext="dylib" ;;
-    linux*)   dylib_ext="so"    ;;
-    bsd*)     dylib_ext="so"    ;;
-    msys*)    dylib_ext="dll"   ;;
-    *)        dylib_ext="dylib" ;;
+    darwin*) dylib_ext="dylib" ;;
+    linux*) dylib_ext="so" ;;
+    bsd*) dylib_ext="so" ;;
+    msys*) dylib_ext="dll" ;;
+    *) dylib_ext="dylib" ;;
   esac
   find "$haxe_path/bin" -mindepth 1 -maxdepth 1 \
     -type l -path "*neko*.$dylib_ext" \
-    -exec sh -c 'dirname {} | xargs dirname | xargs basename' \; -quit
+    -exec sh -c 'dirname $1 | xargs dirname | xargs basename' _ {} \; -quit
 }
 
 case "$*" in

--- a/lib/commands/command-neko.bash
+++ b/lib/commands/command-neko.bash
@@ -54,8 +54,8 @@ dylibs_link() {
   dylib_ext="dylib"
   case "$OSTYPE" in
     darwin*) dylib_ext="dylib" ;;
-    linux*) dylib_ext="so" ;;
-    bsd*) dylib_ext="so" ;;
+    linux*) dylib_ext="so*" ;;
+    bsd*) dylib_ext="so*" ;;
     msys*) dylib_ext="dll" ;;
     *) dylib_ext="dylib" ;;
   esac
@@ -70,8 +70,8 @@ dylibs_unlink() {
   dylib_ext="dylib"
   case "$OSTYPE" in
     darwin*) dylib_ext="dylib" ;;
-    linux*) dylib_ext="so" ;;
-    bsd*) dylib_ext="so" ;;
+    linux*) dylib_ext="so*" ;;
+    bsd*) dylib_ext="so*" ;;
     msys*) dylib_ext="dll" ;;
     *) dylib_ext="dylib" ;;
   esac
@@ -86,8 +86,8 @@ dylibs_which() {
   dylib_ext="dylib"
   case "$OSTYPE" in
     darwin*) dylib_ext="dylib" ;;
-    linux*) dylib_ext="so" ;;
-    bsd*) dylib_ext="so" ;;
+    linux*) dylib_ext="so*" ;;
+    bsd*) dylib_ext="so*" ;;
     msys*) dylib_ext="dll" ;;
     *) dylib_ext="dylib" ;;
   esac

--- a/lib/commands/command-neko.bash
+++ b/lib/commands/command-neko.bash
@@ -51,25 +51,53 @@ dylibs_link() {
   local haxe_path neko_path
   haxe_path=$(asdf where haxe)
   neko_path=$(asdf where neko)
+  dylib_ext="dylib"
+  case "$OSTYPE" in
+    solaris*) dylib_ext="so"    ;;
+    darwin*)  dylib_ext="dylib" ;;
+    linux*)   dylib_ext="so"    ;;
+    bsd*)     dylib_ext="so"    ;;
+    msys*)    dylib_ext="dll"   ;;
+    *)        dylib_ext="dylib" ;;
+  esac
   find "$neko_path/bin" -mindepth 1 -maxdepth 1 \
-    -name "*.dylib" \
+    -name "*.$dylib_ext" \
     -exec ln -sfv {} "$haxe_path/bin" \;
 }
 
 dylibs_unlink() {
   local haxe_path
   haxe_path=$(asdf where haxe)
+  dylib_ext="dylib"
+  case "$OSTYPE" in
+    solaris*) dylib_ext="so"    ;;
+    darwin*)  dylib_ext="dylib" ;;
+    linux*)   dylib_ext="so"    ;;
+    bsd*)     dylib_ext="so"    ;;
+    msys*)    dylib_ext="dll"   ;;
+    *)        dylib_ext="dylib" ;;
+  esac
   find "$haxe_path/bin" -mindepth 1 -maxdepth 1 \
-    -type l -path "*neko*.dylib" \
+    -type l -path "*neko*.$dylib_ext" \
     -exec rm -v {} \;
 }
 
 dylibs_which() {
+  set -x
   local haxe_path
   haxe_path=$(asdf where haxe)
+  dylib_ext="dylib"
+  case "$OSTYPE" in
+    solaris*) dylib_ext="so"    ;;
+    darwin*)  dylib_ext="dylib" ;;
+    linux*)   dylib_ext="so"    ;;
+    bsd*)     dylib_ext="so"    ;;
+    msys*)    dylib_ext="dll"   ;;
+    *)        dylib_ext="dylib" ;;
+  esac
   find "$haxe_path/bin" -mindepth 1 -maxdepth 1 \
-    -type l -path "*neko*.dylib" | head -n 1 |
-    xargs dirname | xargs dirname | xargs basename
+    -type l -path "*neko*.$dylib_ext" \
+    -exec sh -c 'dirname {} | xargs dirname | xargs basename' \; -quit
 }
 
 case "$*" in


### PR DESCRIPTION
This allows asdf to link the dylibs for other plafroms besides OSX.

```shell
# thiago @ SeaMonkey in ~/Projects/gamedev/asdf-haxe on git:master o [10:08:39] 
$ asdf haxe neko dylibs which
4.1.3

# thiago @ SeaMonkey in ~/Projects/gamedev/asdf-haxe on git:master o [10:10:00] 
$ asdf haxe neko dylibs unlink
removed '/home/thiago/.asdf/installs/haxe/4.1.3/bin/libneko.so'

# thiago @ SeaMonkey in ~/Projects/gamedev/asdf-haxe on git:master o [10:10:07] 
$ asdf haxe neko dylibs link  
'/home/thiago/.asdf/installs/haxe/4.1.3/bin/libneko.so' -> '/home/thiago/.asdf/installs/neko/2.3.0/bin/libneko.so'

# thiago @ SeaMonkey in ~/Projects/gamedev/asdf-haxe on git:master o [10:10:10] 
$ asdf haxe neko dylibs which 
4.1.3
```